### PR TITLE
fix: access correct private property _achternaam

### DIFF
--- a/javascript-basics.nl.md
+++ b/javascript-basics.nl.md
@@ -798,7 +798,7 @@ class Cursist {
   }
 
   set achternaam(achternaam) {
-    this.achternaam = achternaam;
+    this._achternaam = achternaam;
   }
 
   get naam() {


### PR DESCRIPTION
add the underscore to access the class its 'private' property